### PR TITLE
Extending dependencies listed in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ Dependencies
 * argparse
 * lxml
 
+If you use the build script provided to install these dependencies, you will need a
+working C compiler (eg. GCC), the python and libxml development headers, and the xslt-config tool (typically
+found in the libxslt(1)-dev package or similar, provided by your package manager).
+
 Installation
 ------------
 


### PR DESCRIPTION
Running `sudo python setup.py install` fetches the dependencies, and then tries to build them. However, it fails without the right -dev packages. I'm not particularly attached to the way I wrote up the added blurb - I'm sure it could be improved! But it would be nice if this was mentioned in the README already.
