### PR TITLE
support base urls with upstream kvp

### DIFF
--- a/oval/validator.py
+++ b/oval/validator.py
@@ -92,8 +92,10 @@ def normalize_base_url(url):
     url = url.strip()
     if '?verb=' in url:
         url = url[:url.index('verb=')]
-    elif url.endswith('?') or '?' in url:
+    elif url.endswith('?'):
         pass
+    elif '?' in url and not url.endswith('?'):
+        url = url + '&'    
     else:
         url = url + '?'
     return url

--- a/oval/validator.py
+++ b/oval/validator.py
@@ -92,7 +92,7 @@ def normalize_base_url(url):
     url = url.strip()
     if '?verb=' in url:
         url = url[:url.index('verb=')]
-    elif url.endswith('?'):
+    elif url.endswith('?') or '?' in url:
         pass
     else:
         url = url + '?'


### PR DESCRIPTION
This PR allows the validator support for base URLs like:

http://host/mycatalog?mode=oaipmh